### PR TITLE
feat(logging): add logging command to fast track setting levels

### DIFF
--- a/src/accountfactory.js
+++ b/src/accountfactory.js
@@ -49,13 +49,22 @@ async function main() {
     .option('--username <username>', 'IAM username to create in each account', 'deploy')
     .option('--overwrite', 'Overwrite existing accounts', false)
     .option('--skipconfirmation', 'Skip confirmation prompt', false)
-    .action((options) => commandHandler.handleCreateAccounts(options));
+    .action(options => commandHandler.handleCreateAccounts(options));
 
   program
     .command('setup-aws-profiles')
     .description('🔧 Configure AWS profiles using creds from Secrets Manager')
     .option('--username <username>', 'IAM username to use', 'deploy')
     .action(() => commandHandler.handleSetupAwsProfiles());
+
+  program
+    .command('logging')
+    .description('🔧 Set log level and enable/disable file logging')
+    .option('--loglevel <level>', 'Set log level (e.g., debug, info, warning, error)', 'info')
+    .option('--file-logging <enable>', 'Enable (true) or disable (false) file logging', 'false')
+    .action(options => {
+      commandHandler.handleSetLogConfig(options);
+    });
 
   program.parse();
 }

--- a/src/clients/iamService.js
+++ b/src/clients/iamService.js
@@ -8,7 +8,7 @@ import {
 import { AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { ADMIN_POLICY_ARN, ORGANIZATION_ROLE_NAME } from '../constants.js';
 import { PasswordService } from '../utils/passwordService.js';
-import { logger } from "../utils/logger.js";
+import { logger } from '../utils/logger.js';
 
 export class IAMService {
   constructor(iamClient, secretsManagerClient, stsClient, injectedLogger = logger) {

--- a/src/clients/iamService.test.js
+++ b/src/clients/iamService.test.js
@@ -39,7 +39,6 @@ const testUser = {
 };
 
 describe('IAMService', () => {
-
   describe('constructor', () => {
     test('should initialize with provided clients', async () => {
       const { IAMService } = await import('./iamService.js');
@@ -57,7 +56,9 @@ describe('IAMService', () => {
 
     test('should throw error when SecretsManagerClient is not provided', async () => {
       const { IAMService } = await import('./iamService.js');
-      expect(() => new IAMService(iamMock, null, stsMock)).toThrow('SecretsManagerClient is required');
+      expect(() => new IAMService(iamMock, null, stsMock)).toThrow(
+        'SecretsManagerClient is required'
+      );
     });
 
     test('should throw error when STSClient is not provided', async () => {
@@ -146,7 +147,7 @@ describe('IAMService', () => {
         secretAccessKey: testAccessKey.AccessKey.SecretAccessKey,
       });
     });
-    
+
     test('should handle existing login profile with HTTP 409 status code', async () => {
       const error = new Error('Profile exists');
       error.$metadata = { httpStatusCode: 409 };

--- a/src/clients/organizationsService.js
+++ b/src/clients/organizationsService.js
@@ -3,11 +3,13 @@ import {
   DescribeCreateAccountStatusCommand,
   ListAccountsCommand,
 } from '@aws-sdk/client-organizations';
-import { logger } from "../utils/logger.js";
+import { logger } from '../utils/logger.js';
 
 export class OrganizationsService {
   constructor(organizationsClient, delayBetweenOperations = 15000, injectedLogger = logger) {
-    if (!organizationsClient) {throw new Error('OrganizationsClient is required');}
+    if (!organizationsClient) {
+      throw new Error('OrganizationsClient is required');
+    }
     this.client = organizationsClient;
     this.DELAY_BETWEEN_OPERATIONS = delayBetweenOperations;
     this.logger = injectedLogger;

--- a/src/clients/secretsManagerService.js
+++ b/src/clients/secretsManagerService.js
@@ -3,11 +3,13 @@ import {
   GetSecretValueCommand,
   PutSecretValueCommand,
 } from '@aws-sdk/client-secrets-manager';
-import { logger } from "../utils/logger.js";
+import { logger } from '../utils/logger.js';
 
 export class SecretsManagerService {
   constructor(secretsManagerClient, injectedLogger = logger) {
-    if (!secretsManagerClient) {throw new Error('SecretsManagerClient is required');}
+    if (!secretsManagerClient) {
+      throw new Error('SecretsManagerClient is required');
+    }
     this.client = secretsManagerClient;
     this.logger = injectedLogger;
     this.logger.debug('SecretsManagerService initialized with all required dependencies');
@@ -45,7 +47,9 @@ export class SecretsManagerService {
             ],
           })
         );
-        this.logger.success(`Stored credentials in parent account's Secrets Manager as ${secretName}`);
+        this.logger.success(
+          `Stored credentials in parent account's Secrets Manager as ${secretName}`
+        );
       } catch (error) {
         if (error.name === 'ResourceExistsException') {
           // If secret exists, update it

--- a/src/clients/secretsManagerService.test.js
+++ b/src/clients/secretsManagerService.test.js
@@ -70,8 +70,10 @@ describe('SecretsManagerService', () => {
 
     test('should update existing secret when it already exists', async () => {
       secretsManagerMock
-        .on(CreateSecretCommand).rejects({ name: 'ResourceExistsException' })
-        .on(PutSecretValueCommand).resolves({});
+        .on(CreateSecretCommand)
+        .rejects({ name: 'ResourceExistsException' })
+        .on(PutSecretValueCommand)
+        .resolves({});
 
       const { SecretsManagerService } = await import('./secretsManagerService.js');
       const service = new SecretsManagerService(secretsManagerMock);
@@ -91,8 +93,7 @@ describe('SecretsManagerService', () => {
 
     test('should throw error when AWS operation fails', async () => {
       const errorMessage = 'AWS operation failed';
-      secretsManagerMock
-        .on(CreateSecretCommand).rejects(new Error(errorMessage));
+      secretsManagerMock.on(CreateSecretCommand).rejects(new Error(errorMessage));
 
       const { SecretsManagerService } = await import('./secretsManagerService.js');
       const service = new SecretsManagerService(secretsManagerMock);

--- a/src/clients/stsService.js
+++ b/src/clients/stsService.js
@@ -1,9 +1,11 @@
 import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
-import { logger } from "../utils/logger.js";
+import { logger } from '../utils/logger.js';
 
 export class STSService {
   constructor(stsClient, injectedLogger = logger) {
-    if (!stsClient) {throw new Error('STSClient is required');}
+    if (!stsClient) {
+      throw new Error('STSClient is required');
+    }
     this.stsClient = stsClient;
     this.logger = injectedLogger;
     this.logger.debug('STSService initialized with all required dependencies');

--- a/src/clients/stsService.test.js
+++ b/src/clients/stsService.test.js
@@ -23,7 +23,10 @@ describe('STSService', () => {
       expect(() => new STSService(stsClientMock, testLogger)).not.toThrow();
       const logs = testLogger.getLogEntries();
       expect(logs).toHaveLength(1);
-      expect(logs).toContainEqual({ level: 'debug', message: 'STSService initialized with all required dependencies' });
+      expect(logs).toContainEqual({
+        level: 'debug',
+        message: 'STSService initialized with all required dependencies',
+      });
     });
   });
 
@@ -32,7 +35,7 @@ describe('STSService', () => {
       const mockResponse = {
         Account: '123456789012',
         Arn: 'arn:aws:iam::123456789012:user/test-user',
-        UserId: 'AIDAXXXXXXXXXXXXXXXX'
+        UserId: 'AIDAXXXXXXXXXXXXXXXX',
       };
 
       stsClientMock.on(GetCallerIdentityCommand).resolves(mockResponse);
@@ -49,14 +52,17 @@ describe('STSService', () => {
 
       const logs = testLogger.getLogEntries();
       expect(logs).toHaveLength(2);
-      expect(logs).toContainEqual({ level: 'info', message: `AWS account ID: ${mockResponse.Account}` });
+      expect(logs).toContainEqual({
+        level: 'info',
+        message: `AWS account ID: ${mockResponse.Account}`,
+      });
     });
 
     test('should log warning when running as root user', async () => {
       const mockResponse = {
         Account: '123456789012',
         Arn: 'arn:aws:iam::123456789012:root',
-        UserId: 'AIDAXXXXXXXXXXXXXXXX'
+        UserId: 'AIDAXXXXXXXXXXXXXXXX',
       };
 
       stsClientMock.on(GetCallerIdentityCommand).resolves(mockResponse);
@@ -69,13 +75,16 @@ describe('STSService', () => {
       expect(result).toEqual(mockResponse);
       const logs = testLogger.getLogEntries();
       expect(logs).toHaveLength(3);
-      expect(logs).toContainEqual({ level: 'warning', message: `Warning: Running as root user. Consider using an IAM user instead.` });
+      expect(logs).toContainEqual({
+        level: 'warning',
+        message: `Warning: Running as root user. Consider using an IAM user instead.`,
+      });
     });
 
     test('should throw error when account ID is missing', async () => {
       const mockResponse = {
         Arn: 'arn:aws:iam::123456789012:user/test-user',
-        UserId: 'AIDAXXXXXXXXXXXXXXXX'
+        UserId: 'AIDAXXXXXXXXXXXXXXXX',
       };
 
       stsClientMock.on(GetCallerIdentityCommand).resolves(mockResponse);
@@ -100,7 +109,10 @@ describe('STSService', () => {
 
       const logs = testLogger.getLogEntries();
       expect(logs).toHaveLength(2);
-      expect(logs).toContainEqual({ level: 'error', message: `Failed to get caller identity: ${errorMessage}` });
+      expect(logs).toContainEqual({
+        level: 'error',
+        message: `Failed to get caller identity: ${errorMessage}`,
+      });
     });
   });
 });

--- a/src/commands/commandHandlerLogger.tst.js
+++ b/src/commands/commandHandlerLogger.tst.js
@@ -1,0 +1,63 @@
+import { CommandHandler } from './commandHandler';
+import { logger } from '../utils/logger';
+
+describe('CommandHandler', () => {
+  let commandHandler;
+
+  beforeEach(() => {
+    // Mock the logger
+    logger.info = jest.fn();
+    logger.error = jest.fn();
+    logger.debug = jest.fn();
+
+    // Initialize the command handler with mock dependencies
+    commandHandler = new CommandHandler(null, null, null, null, logger);
+  });
+
+  it('should set the log level when loglevel option is provided', async () => {
+    const options = { loglevel: 'debug' };
+    await commandHandler.handleSetLogConfig(options);
+
+    expect(logger.level).toBe('debug');
+    expect(logger.info).toHaveBeenCalledWith('Log level set to debug');
+  });
+
+  it('should enable file logging when fileLogging option is true', async () => {
+    const options = { fileLogging: 'true' };
+    await commandHandler.handleSetLogConfig(options);
+
+    expect(logger.enableFileLogging).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith('File logging enabled');
+  });
+
+  it('should disable file logging when fileLogging option is false', async () => {
+    const options = { fileLogging: 'false' };
+    await commandHandler.handleSetLogConfig(options);
+
+    expect(logger.enableFileLogging).toBe(false);
+    expect(logger.info).toHaveBeenCalledWith('File logging disabled');
+  });
+
+  it('should handle both loglevel and fileLogging options', async () => {
+    const options = { loglevel: 'info', fileLogging: 'true' };
+    await commandHandler.handleSetLogConfig(options);
+
+    expect(logger.level).toBe('info');
+    expect(logger.enableFileLogging).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith('Log level set to info');
+    expect(logger.info).toHaveBeenCalledWith('File logging enabled');
+  });
+
+  it('should handle errors during configuration', async () => {
+    const options = { loglevel: 'invalid' };
+    const error = new Error('Invalid log level');
+    logger.level = jest.fn(() => {
+      throw error;
+    });
+
+    await commandHandler.handleSetLogConfig(options);
+
+    expect(logger.error).toHaveBeenCalledWith(`Command failed: ${error.message}`);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/commands/setupProfilesService.js
+++ b/src/commands/setupProfilesService.js
@@ -1,12 +1,16 @@
 import { exec } from 'child_process';
 import { DEFAULT_REGION } from '../constants.js';
-import { logger } from "../utils/logger.js";
+import { logger } from '../utils/logger.js';
 import { SecretsManagerService } from '../clients/secretsManagerService.js';
 
 export class SetupProfilesService {
   constructor(stsClient, secretsManagerClient, injectedLogger = logger) {
-    if (!stsClient) {throw new Error('STSClient is required');}
-    if (!secretsManagerClient) {throw new Error('SecretsManagerClient is required');}
+    if (!stsClient) {
+      throw new Error('STSClient is required');
+    }
+    if (!secretsManagerClient) {
+      throw new Error('SecretsManagerClient is required');
+    }
     this.stsClient = stsClient;
     this.secretsManagerClient = secretsManagerClient;
     this.logger = injectedLogger;
@@ -26,7 +30,9 @@ export class SetupProfilesService {
         );
       }
 
-      this.logger.info(`Getting existing credentials for user ${options.username} in account ${account.Id}`);
+      this.logger.info(
+        `Getting existing credentials for user ${options.username} in account ${account.Id}`
+      );
       const credentials = await this.secretsManagerService.getExistingCredentials(
         account.Id,
         options.username
@@ -35,7 +41,7 @@ export class SetupProfilesService {
       if (!credentials) {
         throw new Error(
           `No credentials found for user ${options.username} in account ${account.Id}. ` +
-          `Please run "accountfactory create-accounts --username ${options.username}" first to create the IAM user and store credentials.`
+            `Please run "accountfactory create-accounts --username ${options.username}" first to create the IAM user and store credentials.`
         );
       }
 
@@ -62,11 +68,12 @@ export class SetupProfilesService {
       }
 
       this.logger.success(`Successfully configured AWS profile '${accountConfig.profileName}' 🎉`);
-      this.logger.info(`You can now use this profile with: aws --profile ${accountConfig.profileName} [command]`);
+      this.logger.info(
+        `You can now use this profile with: aws --profile ${accountConfig.profileName} [command]`
+      );
     } catch (error) {
       this.logger.error(`Failed to set up AWS profile: ${error.message}`);
       throw error;
     }
   }
-
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -9,7 +9,7 @@ export class Logger {
     const {
       level = process.env.ACCOUNTFACTORY_LOG_LEVEL || 'info',
       silent = process.env.NODE_ENV === 'test',
-      enableFileLogging = process.env.ACCOUNTFACTORY_ENABLE_LOGGING === 'true'
+      enableFileLogging = process.env.ACCOUNTFACTORY_ENABLE_LOGGING === 'true',
     } = options;
 
     this.customLevels = {
@@ -26,7 +26,7 @@ export class Logger {
         success: 'green',
         info: 'white',
         debug: 'gray',
-      }
+      },
     };
 
     this.transports = this.createTransports({ level, silent, enableFileLogging });
@@ -44,16 +44,17 @@ export class Logger {
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.printf(({ timestamp, level, message }) => {
-            const color = {
-              debug: chalk.gray,
-              info: chalk.white,
-              success: chalk.green,
-              error: chalk.red,
-              warning: chalk.yellow,
-            }[level] || chalk.white;
+            const color =
+              {
+                debug: chalk.gray,
+                info: chalk.white,
+                success: chalk.green,
+                error: chalk.red,
+                warning: chalk.yellow,
+              }[level] || chalk.white;
             return color(`[${timestamp}] [${level.toUpperCase()}] ${message}`);
           })
-        )
+        ),
       })
     );
 
@@ -64,7 +65,7 @@ export class Logger {
 
       transports.push(
         new winston.transports.File({
-          filename: join(logDirectory, 'accountfactory.log')
+          filename: join(logDirectory, 'accountfactory.log'),
         })
       );
     }
@@ -75,7 +76,7 @@ export class Logger {
   createLogger() {
     return winston.createLogger({
       levels: this.customLevels.levels,
-      transports: this.transports
+      transports: this.transports,
     });
   }
 
@@ -97,11 +98,21 @@ export class Logger {
   }
 
   // Logging methods
-  debug(message) { this.logger.debug(message); }
-  info(message) { this.logger.info(message); }
-  success(message) { this.logger.log('success', message); }
-  warning(message) { this.logger.log('warning', message); }
-  error(message) { this.logger.error(message); }
+  debug(message) {
+    this.logger.debug(message);
+  }
+  info(message) {
+    this.logger.info(message);
+  }
+  success(message) {
+    this.logger.log('success', message);
+  }
+  warning(message) {
+    this.logger.log('warning', message);
+  }
+  error(message) {
+    this.logger.error(message);
+  }
 
   // Test helpers
   getLogEntries() {
@@ -114,7 +125,7 @@ export class Logger {
   clearLogEntries() {
     this.transports
       .filter(t => t instanceof winston.transports.Console)
-      .forEach(t => t.history = []);
+      .forEach(t => (t.history = []));
   }
 }
 

--- a/src/utils/passwordService.js
+++ b/src/utils/passwordService.js
@@ -1,29 +1,29 @@
 export class PasswordService {
   static generatePassword() {
-      const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-      const lowercase = 'abcdefghijklmnopqrstuvwxyz';
-      const numbers = '0123456789';
-      const special = '!@#$%^&*';
+    const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const lowercase = 'abcdefghijklmnopqrstuvwxyz';
+    const numbers = '0123456789';
+    const special = '!@#$%^&*';
 
-      // Ensure one of each type
-      let password = '';
-      password += uppercase[Math.floor(Math.random() * uppercase.length)];
-      password += lowercase[Math.floor(Math.random() * lowercase.length)];
-      password += numbers[Math.floor(Math.random() * numbers.length)];
-      password += special[Math.floor(Math.random() * special.length)];
+    // Ensure one of each type
+    let password = '';
+    password += uppercase[Math.floor(Math.random() * uppercase.length)];
+    password += lowercase[Math.floor(Math.random() * lowercase.length)];
+    password += numbers[Math.floor(Math.random() * numbers.length)];
+    password += special[Math.floor(Math.random() * special.length)];
 
-      // Fill the rest randomly
-      const allChars = uppercase + lowercase + numbers + special;
-      for (let i = password.length; i < 12; i++) {
-          password += allChars[Math.floor(Math.random() * allChars.length)];
-      }
+    // Fill the rest randomly
+    const allChars = uppercase + lowercase + numbers + special;
+    for (let i = password.length; i < 12; i++) {
+      password += allChars[Math.floor(Math.random() * allChars.length)];
+    }
 
-      // Shuffle the password to make it more random
-      return password
-        .split('')
-        .sort(() => Math.random() - 0.5)
-        .join('');
-  };
+    // Shuffle the password to make it more random
+    return password
+      .split('')
+      .sort(() => Math.random() - 0.5)
+      .join('');
+  }
 }
 
 export const passwordService = new PasswordService();

--- a/src/utils/testLogger.js
+++ b/src/utils/testLogger.js
@@ -16,17 +16,34 @@ export const createTestLogger = () => {
       info: 3,
       debug: 4,
     },
-    transports: [testTransport]
+    transports: [testTransport],
   });
 
   const testLogger = {
-    debug: (msg) => { logger.debug(msg); logs.push({ level: 'debug', message: msg }); },
-    info: (msg) => { logger.info(msg); logs.push({ level: 'info', message: msg }); },
-    success: (msg) => { logger.log('success', msg); logs.push({ level: 'success', message: msg }); },
-    error: (msg) => { logger.error(msg); logs.push({ level: 'error', message: msg }); },
-    warning: (msg) => { logger.log('warning', msg); logs.push({ level: 'warning', message: msg }); },
+    debug: msg => {
+      logger.debug(msg);
+      logs.push({ level: 'debug', message: msg });
+    },
+    info: msg => {
+      logger.info(msg);
+      logs.push({ level: 'info', message: msg });
+    },
+    success: msg => {
+      logger.log('success', msg);
+      logs.push({ level: 'success', message: msg });
+    },
+    error: msg => {
+      logger.error(msg);
+      logs.push({ level: 'error', message: msg });
+    },
+    warning: msg => {
+      logger.log('warning', msg);
+      logs.push({ level: 'warning', message: msg });
+    },
     getLogEntries: () => [...logs],
-    clearLogs: () => { logs.length = 0; }
+    clearLogs: () => {
+      logs.length = 0;
+    },
   };
 
   return testLogger;

--- a/src/utils/testLogger.test.js
+++ b/src/utils/testLogger.test.js
@@ -2,11 +2,11 @@ import { createTestLogger } from './testLogger';
 
 describe('testLogger', () => {
   let testLogger;
-  
+
   beforeEach(() => {
     testLogger = createTestLogger();
   });
-  
+
   it('should create a testLogger with the required methods', () => {
     expect(testLogger).toHaveProperty('debug');
     expect(testLogger).toHaveProperty('info');
@@ -16,92 +16,92 @@ describe('testLogger', () => {
     expect(testLogger).toHaveProperty('getLogEntries');
     expect(testLogger).toHaveProperty('clearLogs');
   });
-  
+
   it('should log debug messages', () => {
     testLogger.debug('test debug message');
     const logs = testLogger.getLogEntries();
-    
+
     expect(logs).toHaveLength(1);
     expect(logs[0]).toEqual({
       level: 'debug',
-      message: 'test debug message'
+      message: 'test debug message',
     });
   });
-  
+
   it('should log info messages', () => {
     testLogger.info('test info message');
     const logs = testLogger.getLogEntries();
-    
+
     expect(logs).toHaveLength(1);
     expect(logs[0]).toEqual({
       level: 'info',
-      message: 'test info message'
+      message: 'test info message',
     });
   });
-  
+
   it('should log success messages', () => {
     testLogger.success('test success message');
     const logs = testLogger.getLogEntries();
-    
+
     expect(logs).toHaveLength(1);
     expect(logs[0]).toEqual({
       level: 'success',
-      message: 'test success message'
+      message: 'test success message',
     });
   });
-  
+
   it('should log error messages', () => {
     testLogger.error('test error message');
     const logs = testLogger.getLogEntries();
-    
+
     expect(logs).toHaveLength(1);
     expect(logs[0]).toEqual({
       level: 'error',
-      message: 'test error message'
+      message: 'test error message',
     });
   });
-  
+
   it('should log warning messages', () => {
     testLogger.warning('test warning message');
     const logs = testLogger.getLogEntries();
-    
+
     expect(logs).toHaveLength(1);
     expect(logs[0]).toEqual({
       level: 'warning',
-      message: 'test warning message'
+      message: 'test warning message',
     });
   });
-  
+
   it('should accumulate logs across multiple calls', () => {
     testLogger.info('first message');
     testLogger.debug('second message');
     testLogger.error('third message');
-    
+
     const logs = testLogger.getLogEntries();
-    
+
     expect(logs).toHaveLength(3);
     expect(logs[0]).toEqual({ level: 'info', message: 'first message' });
     expect(logs[1]).toEqual({ level: 'debug', message: 'second message' });
     expect(logs[2]).toEqual({ level: 'error', message: 'third message' });
   });
-  
+
   it('should clear logs when clearLogs is called', () => {
     testLogger.info('test message');
     expect(testLogger.getLogEntries()).toHaveLength(1);
-    
+
     testLogger.clearLogs();
     expect(testLogger.getLogEntries()).toHaveLength(0);
   });
-  
+
   it('should return a copy of logs from getLogEntries', () => {
     testLogger.info('test message');
-    
+
     const logs1 = testLogger.getLogEntries();
     expect(logs1).toHaveLength(1);
-    
+
     // Modify the returned array
     logs1.push({ level: 'debug', message: 'added message' });
-    
+
     // Get logs again and verify the original logs array wasn't modified
     const logs2 = testLogger.getLogEntries();
     expect(logs2).toHaveLength(1);


### PR DESCRIPTION
I think this works, but I tested this without actually creating accounts but it should be like this from programming pov, please review and test!

also I formatted the codebase with ```npm run format``` so it suits well on my eyes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line logging configuration option that allows users to set the log level and toggle file logging.

- **Refactor/Style**
  - Improved formatting and structure across various components for enhanced readability and maintainability.

- **Tests**
  - Added and refined tests to verify the new logging configuration functionality and ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->